### PR TITLE
#12 Fixing async adapt issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydyno_pool"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
     { name = "Ryan Davis", email = "ryancraigdavis@gmail.com" },
 ]

--- a/src/pydyno/scripts/test_postgres_adapter.py
+++ b/src/pydyno/scripts/test_postgres_adapter.py
@@ -1,0 +1,36 @@
+import asyncio
+import os
+from pydyno.adapters.postgresql import PostgreSQLAdapter
+from pydyno.core.pool_config import PoolConfig
+
+
+async def test_adapter():
+    config = {
+        "host": "localhost",
+        "port": 5432,
+        "user": os.getenv("POSTGRES_USER", "postgres"),
+        "password": os.getenv("POSTGRES_PASSWORD", "password"),
+        "database": os.getenv("POSTGRES_DB", "test_db"),
+    }
+
+    adapter = PostgreSQLAdapter(
+        name="test", service_type="postgresql", config=config, pool_config=PoolConfig()
+    )
+
+    print(f"Created adapter: {adapter}")
+
+    try:
+        await adapter.initialize()
+        print("✅ Initialization successful")
+    except Exception as e:
+        print(f"❌ Initialization failed: {e}")
+
+    try:
+        await adapter.close()
+        print("✅ Close successful")
+    except Exception as e:
+        print(f"❌ Close failed: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_adapter())


### PR DESCRIPTION
This pull request includes updates to the PostgreSQL adapter in the `pydyno` library, focusing on improving connection handling, simplifying configuration, and adding a test script. The changes also include a version bump in the `pyproject.toml` file to reflect these updates.

### PostgreSQL Adapter Enhancements:

* Removed inline connection parameters like `sslmode` and `application_name` from the database URL in `_build_database_url`, moving their handling to `connect_args` for better flexibility and separation of concerns. (`src/pydyno/adapters/postgresql.py`, [src/pydyno/adapters/postgresql.pyL134-R135](diffhunk://#diff-724d556f371b253465f82e73ee4a28d3bee60281c41812eea0c084b4ed2e9674L134-R135))
* Updated `initialize` to use a `connect_args` variable instead of an inline dictionary, allowing dynamic configuration of connection arguments. Removed event listeners (`connect` and `checkout`) due to async compatibility issues. (`src/pydyno/adapters/postgresql.py`, [[1]](diffhunk://#diff-724d556f371b253465f82e73ee4a28d3bee60281c41812eea0c084b4ed2e9674R149) [[2]](diffhunk://#diff-724d556f371b253465f82e73ee4a28d3bee60281c41812eea0c084b4ed2e9674L189-R188)
* Deprecated connection-specific SQL execution (e.g., enabling extensions) in `_on_connect`, recommending handling such tasks during application startup instead. (`src/pydyno/adapters/postgresql.py`, [src/pydyno/adapters/postgresql.pyL243-R233](diffhunk://#diff-724d556f371b253465f82e73ee4a28d3bee60281c41812eea0c084b4ed2e9674L243-R233))

### Testing and Versioning:

* Added a new script, `test_postgres_adapter.py`, to test the PostgreSQL adapter's initialization and closure, with environment-variable-based configuration for flexibility. (`src/pydyno/scripts/test_postgres_adapter.py`, [src/pydyno/scripts/test_postgres_adapter.pyR1-R36](diffhunk://#diff-6ec7590780657db497dd54018a34baf12902bd1e37411934ebce8108625fe225R1-R36))
* Incremented the package version from `0.1.2` to `0.1.3` in `pyproject.toml` to reflect the updates. (`pyproject.toml`, [pyproject.tomlL3-R3](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3))